### PR TITLE
Add padding to code blocks

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -322,12 +322,20 @@ thead
     background-color: var(--pre-code) !important;
 }
 
+.markdown-rendered pre {
+    padding: 0;
+}
+
 .markdown-rendered code,
 .markdown-preview-section pre code
 {
     padding: 4px !important;
     line-height: 1.4em !important;
     color: var(--code-block) !important;
+}
+
+.markdown-preview-section pre code {
+    padding: 16px !important;
 }
 
 .markdown-preview-section pre code


### PR DESCRIPTION
Adding padding to multi-line code blocks to match Github's rendering

<img width="823" alt="image" src="https://user-images.githubusercontent.com/442889/169671719-4df88f98-dc3c-4c21-9456-e64afee44b55.png">
