### PR TITLE
Fix inline code styling in Live Preview

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1,6 +1,6 @@
 /** 
     Zenburn Theme for Obsidian
-    v0.9.0
+    v0.9.0 (Legacy theme; use theme.css for the latest)
     https://github.com/danyim/obsidian-zenburn
     https://www.buymeacoffee.com/danyim
 */

--- a/theme.css
+++ b/theme.css
@@ -1,6 +1,6 @@
 /**
     Zenburn Theme for Obsidian
-    v1.0.0
+    v1.0.1
     https://github.com/danyim/obsidian-zenburn
     https://www.buymeacoffee.com/danyim
 */
@@ -60,7 +60,7 @@
     --text-highlight-bg-active:   var(--blue-dim);
     --interactive-accent:         var(--yellow-dim);
     --interactive-accent-hover:   var(--yellow);
-    --interactive-before:         var(--blue-dim);
+    --interactive-before:         var(--magenta-dim);
     --background-modifier-border: var(--red);
     --background-modifier-error:  var(--red-dim);
     --text-accent:                var(--cyan);
@@ -374,24 +374,40 @@ pre.HyperMD-table-row.CodeMirror-line > *,
     -webkit-font-smoothing: auto !important;
 }
 
-.cm-inline-code
+.cm-inline-code:not(.cm-formatting-code)
 {
     background-color: var(--pre-code) !important;
     color: var(--inline-code) !important;
     padding: 4px 6px !important;
-    border-radius: 5px;
+    --inline-code-border-radius: 4px;
+    border-radius: var(--inline-code-border-radius);
 }
-span.cm-formatting.cm-formatting-code.cm-inline-code:nth-child(n)
+/* Inline code tick style */
+.cm-formatting.cm-formatting-code
 {
-    /* background-color: none !important; */
-    background-color: red !important;
-    padding: 4px 0px !important;
+    background-color: var(--pre-code) !important;
+    color: var(--inline-code) !important;
+    padding: 4px 0px;
+    border-radius: var(--inline-code-border-radius);
 }
-span.cm-formatting.cm-formatting-code.cm-inline-code:nth-child(2n)
+/* Inline code: opening tick */
+.cm-formatting.cm-formatting-code:nth-of-type(3n+1)
 {
-    /* background-color: none !important; */
-    background-color: blue !important;
-    padding: 4px 0px !important;
+    border-radius: 0;
+    border-top-left-radius: var(--inline-code-border-radius);
+    border-bottom-left-radius: var(--inline-code-border-radius);
+}
+/* Inline code: closing tick */
+.cm-formatting.cm-formatting-code:nth-of-type(3n)
+{
+    border-radius: 0;
+    border-top-right-radius: var(--inline-code-border-radius);
+    border-bottom-right-radius: var(--inline-code-border-radius);
+}
+/* Inline code: between ticks */
+.cm-formatting.cm-formatting-code + .cm-inline-code {
+    border-radius: 0;
+    padding: 4px 2px !important;
 }
 
 .workspace-leaf-header-title

--- a/theme.css
+++ b/theme.css
@@ -335,6 +335,7 @@ thead
     padding: 0;
 }
 
+
 .markdown-rendered code,
 .markdown-preview-section pre code
 {
@@ -377,11 +378,19 @@ pre.HyperMD-table-row.CodeMirror-line > *,
 {
     background-color: var(--pre-code) !important;
     color: var(--inline-code) !important;
+    padding: 4px 6px !important;
+    border-radius: 5px;
+}
+span.cm-formatting.cm-formatting-code.cm-inline-code:nth-child(n)
+{
+    /* background-color: none !important; */
+    background-color: red !important;
     padding: 4px 0px !important;
 }
-.cm-formatting-code.cm-inline-code
+span.cm-formatting.cm-formatting-code.cm-inline-code:nth-child(2n)
 {
-    background-color: none !important;
+    /* background-color: none !important; */
+    background-color: blue !important;
     padding: 4px 0px !important;
 }
 


### PR DESCRIPTION
Fixes the rendering of inline code blocks in Live Preview mode.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/442889/206945936-18d35722-2c70-4bae-b0ce-f7dd18abaeea.png">
In focus:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/442889/206945952-451f4fc8-2073-41ca-8cb9-7b569870817c.png">
