### PR TITLE
Simplify styling for tags

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -42,6 +42,7 @@
     --background-primary-alt:     var(--black-dim);
     --background-secondary:       var(--black);
     --background-secondary-alt:   var(--black);
+    --background-dark:            var(--black);
     --text-normal:                var(--white-bright);
     --text-faint:                 var(--white-bright);
     --text-muted:                 var(--yellow);
@@ -53,17 +54,19 @@
     --text-title-h6:              var(--white-bright);
     --text-link:                  var(--red-dim);
     --text-a:                     var(--red-dim);
-    --text-a-hover:               var(--red-dim);
+    --link-external-color:        var(--red-dim);
+    --text-a-hover:               var(--blue);
+    --link-external-hover-color:  var(--blue);
     --text-mark:                  rgba(136, 192, 208, 0.3); /* frost1 */
     --pre-code:                   var(--black);
     --text-highlight-bg:          var(--blue-dim);
     --text-highlight-bg-active:   var(--blue-dim);
     --interactive-accent:         var(--yellow-dim);
     --interactive-accent-hover:   var(--yellow);
-    --interactive-before:         var(--magenta-dim);
+    --interactive-before:         var(--yellow-dim);
     --background-modifier-border: var(--red);
     --background-modifier-error:  var(--red-dim);
-    --text-accent:                var(--cyan);
+    --text-accent:                var(--red);
     --text-on-accent:             var(--black-dim);
     --interactive-accent-rgb:     var(--cyan);
     --inline-code:                var(--green);
@@ -77,6 +80,15 @@
     --table-row-odd:              var(--black-dim);
     --table-hover:                var(--black-bright);
     --color-text-weeknum:         var(--red-dim);
+
+    --tag-color:                  var(--red-dim);
+    --tag-color-hover:            var(--red);
+    --tag-background:             var(--background-dark);
+    --tag-background-hover:       var(--background-dim);
+    --tag-radius:                 0.55em;
+    --tag-padding-x:              0.45em;
+    --tag-padding-y:              0.25em;
+    --tag-decoration-hover:       underline;
 }
 
 body
@@ -140,14 +152,6 @@ a:hover,
 {
     color: var(--text-a-hover) !important;
     text-decoration: none !important;
-}
-
-a.tag, a.tag:hover
-{
-  color: var(--text-tag) !important;
-  background-color: var(--black);
-  padding: 3px 8px;
-  border-radius: 10px;
 }
 
 a.tag:hover
@@ -290,31 +294,6 @@ thead
     font-family: var(--font-text-theme);
     color: var(--black-bright) !important;
     font-weight: 200 !important;
-}
-
-.cm-hashtag-begin
-{
-    color: var(--text-tag) !important;
-    background-color: var(--background-secondary-alt);
-    padding: 2px 0 2px 4px;
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-    text-decoration: none !important;
-}
-
-.cm-hashtag-end
-{
-    color: var(--text-tag) !important;
-    background-color: var(--background-secondary-alt);
-    padding: 2px 4px 2px 0;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    text-decoration: none !important;
-}
-
-.cm-hashtag-begin:hover, .cm-hashtag-end:hover
-{
-    text-decoration: underline !important;
 }
 
 .search-result-file-matched-text
@@ -661,7 +640,8 @@ input[type="text"]::placeholder
 /* Toast notices on the top right of the interface */
 .notice-container .notice
 {
-    background-color: var(--interactive-before) !important;
+    background-color: var(--interactive-accent) !important;
+    color: var(--text-on-accent) !important;
 }
 
 .community-theme.is-selected


### PR DESCRIPTION
Many CSS variables are now available for themes to modify, which means less CSS in this theme and most `!important`-ly less style overrides.

This should also resolve #26 in a more semantic way.

<img width="325" alt="image" src="https://user-images.githubusercontent.com/442889/206950186-e7f6948c-cdb4-4e69-a7f4-2b3d534ab8c2.png">
Hover:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/442889/206950200-ee60eda4-2c5b-4717-bab2-222d70ea1458.png">
