### PR TITLE
Fix URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Zenburn",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "minAppVersion": "1.0.0",
   "author": "@danyim",
   "authorUrl": "https://github.com/danyim"

--- a/theme.css
+++ b/theme.css
@@ -1,6 +1,6 @@
 /**
     Zenburn Theme for Obsidian
-    v1.0.3
+    v1.0.4
     https://github.com/danyim/obsidian-zenburn
     https://www.buymeacoffee.com/danyim
 */
@@ -54,6 +54,7 @@
     --text-link:                  var(--red-dim);
     --text-a:                     var(--red-dim);
     --text-a-hover:               var(--red-dim);
+    --link-external-color:        var(--red-dim);
     --link-external-hover-color:  var(--red);
     --text-mark:                  rgba(136, 192, 208, 0.3); /* frost1 */
     --pre-code:                   var(--black);
@@ -170,6 +171,16 @@ mark
 
 ol, ul {
     margin: 0.25rem 0;
+}
+
+/** Ensures the format string after links have a different color */
+.cm-formatting-link-string
+{
+    color: var(--text-faint) !important;
+    text-decoration-line: none !important;
+}
+.cm-formatting-link-string + .cm-url {
+    color: var(--blue) !important;
 }
 
 .titlebar


### PR DESCRIPTION
Fixing a regression from v1.0.0 where URLs should be styled differently in `[foo](...)` expressions
Before (bug):
<img width="807" alt="image" src="https://user-images.githubusercontent.com/442889/206968846-39bd113b-4063-4ba6-8394-d21b1220c689.png">


Source/Live Preview:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/442889/206968579-d20215ca-87da-4fa8-9689-74fba19eff1f.png">
Reading:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/442889/206968600-281e2f07-6fc3-4e0b-9480-fcf5137086bf.png">
